### PR TITLE
Add gitignore and some other improvements

### DIFF
--- a/elmish-land.fsproj
+++ b/elmish-land.fsproj
@@ -12,6 +12,12 @@
         <EmbeddedResource Include="src/templates/package.json">
             <LogicalName>templates.package.json</LogicalName>
         </EmbeddedResource>
+        <EmbeddedResource Include="src/templates/.gitignore">
+            <LogicalName>templates..gitignore</LogicalName>
+        </EmbeddedResource>
+        <EmbeddedResource Include="src/templates/settings.json">
+            <LogicalName>templates.settings.json</LogicalName>
+        </EmbeddedResource>
         <EmbeddedResource Include="src/templates/PROJECT_NAME.fsproj">
             <LogicalName>templates.PROJECT_NAME.fsproj</LogicalName>
         </EmbeddedResource>

--- a/src/Base.fs
+++ b/src/Base.fs
@@ -47,6 +47,9 @@ type Log
 module String =
     let asLines (s: string) = s.Split(Environment.NewLine)
 
+    let asKebabCase (s: string) =
+        s.Replace(" ", "-").Replace("_", "-").ToLower()
+
 let appFilePath =
     lazy
         let location = Assembly.GetExecutingAssembly().Location

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -13,10 +13,7 @@ let init (projectDir: AbsoluteProjectDir) =
 
         let writeResource = writeResource projectDir
 
-        writeResource
-            "PROJECT_NAME.fsproj"
-            [ $"%s{(ProjectName.asString >> String.asKebabCase) projectName}.fsproj" ]
-            None
+        writeResource "PROJECT_NAME.fsproj" [ $"%s{(ProjectName.asString) projectName}.fsproj" ] None
 
         writeResource "global.json" [ "global.json" ] None
         writeResource "index.html" [ "index.html" ] None
@@ -25,7 +22,7 @@ let init (projectDir: AbsoluteProjectDir) =
         writeResource
             "package.json"
             [ "package.json" ]
-            (Some(fun x -> x.Replace("{{PROJECT_NAME}}", ProjectName.asString projectName)))
+            (Some(fun x -> x.Replace("{{PROJECT_NAME}}" |> String.asKebabCase, ProjectName.asString projectName)))
 
         writeResource "dotnet-tools.json" [ ".config"; "dotnet-tools.json" ] None
         writeResource "settings.json" [ ".vscode"; "settings.json" ] None

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -22,6 +22,7 @@ let init (projectDir: AbsoluteProjectDir) =
             (Some(fun x -> x.Replace("{{PROJECT_NAME}}", ProjectName.asString projectName)))
 
         writeResource "dotnet-tools.json" [ ".config"; "dotnet-tools.json" ] None
+        writeResource "settings.json" [ ".vscode"; "settings.json" ] None
 
         let rootModuleName = projectName |> ProjectName.asString |> quoteIfNeeded
 

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -10,9 +10,9 @@ let init (projectDir: AbsoluteProjectDir) =
         let log = Log()
         log.Info("Initializing project. {}", AbsoluteProjectDir.asString projectDir)
         let projectName = projectDir |> ProjectName.fromProjectDir
+        
         let writeResource = writeResource projectDir
         writeResource "PROJECT_NAME.fsproj" [ $"%s{ProjectName.asString projectName}.fsproj" ] None
-
         writeResource "global.json" [ "global.json" ] None
         writeResource "index.html" [ "index.html" ] None
         writeResource ".gitignore" [ ".gitignore" ] None

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -10,9 +10,7 @@ let init (projectDir: AbsoluteProjectDir) =
         let log = Log()
         log.Info("Initializing project. {}", AbsoluteProjectDir.asString projectDir)
         let projectName = projectDir |> ProjectName.fromProjectDir
-
         let writeResource = writeResource projectDir
-
         writeResource "PROJECT_NAME.fsproj" [ $"%s{ProjectName.asString projectName}.fsproj" ] None
 
         writeResource "global.json" [ "global.json" ] None

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -10,7 +10,7 @@ let init (projectDir: AbsoluteProjectDir) =
         let log = Log()
         log.Info("Initializing project. {}", AbsoluteProjectDir.asString projectDir)
         let projectName = projectDir |> ProjectName.fromProjectDir
-        
+
         let writeResource = writeResource projectDir
         writeResource "PROJECT_NAME.fsproj" [ $"%s{ProjectName.asString projectName}.fsproj" ] None
         writeResource "global.json" [ "global.json" ] None

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -13,7 +13,7 @@ let init (projectDir: AbsoluteProjectDir) =
 
         let writeResource = writeResource projectDir
 
-        writeResource "PROJECT_NAME.fsproj" [ $"%s{(ProjectName.asString) projectName}.fsproj" ] None
+        writeResource "PROJECT_NAME.fsproj" [ $"%s{ProjectName.asString projectName}.fsproj" ] None
 
         writeResource "global.json" [ "global.json" ] None
         writeResource "index.html" [ "index.html" ] None
@@ -22,7 +22,7 @@ let init (projectDir: AbsoluteProjectDir) =
         writeResource
             "package.json"
             [ "package.json" ]
-            (Some(fun x -> x.Replace("{{PROJECT_NAME}}" |> String.asKebabCase, ProjectName.asString projectName)))
+            (Some(fun x -> x.Replace("{{PROJECT_NAME}}", (ProjectName.asString >> String.asKebabCase) projectName)))
 
         writeResource "dotnet-tools.json" [ ".config"; "dotnet-tools.json" ] None
         writeResource "settings.json" [ ".vscode"; "settings.json" ] None

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -12,7 +12,12 @@ let init (projectDir: AbsoluteProjectDir) =
         let projectName = projectDir |> ProjectName.fromProjectDir
 
         let writeResource = writeResource projectDir
-        writeResource "PROJECT_NAME.fsproj" [ $"%s{(ProjectName.asString >> String.asKebabCase) projectName}.fsproj" ] None
+
+        writeResource
+            "PROJECT_NAME.fsproj"
+            [ $"%s{(ProjectName.asString >> String.asKebabCase) projectName}.fsproj" ]
+            None
+
         writeResource "global.json" [ "global.json" ] None
         writeResource "index.html" [ "index.html" ] None
         writeResource ".gitignore" [ ".gitignore" ] None

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -12,7 +12,7 @@ let init (projectDir: AbsoluteProjectDir) =
         let projectName = projectDir |> ProjectName.fromProjectDir
 
         let writeResource = writeResource projectDir
-        writeResource "PROJECT_NAME.fsproj" [ $"%s{ProjectName.asString projectName}.fsproj" ] None
+        writeResource "PROJECT_NAME.fsproj" [ $"%s{(ProjectName.asString >> String.asKebabCase) projectName}.fsproj" ] None
         writeResource "global.json" [ "global.json" ] None
         writeResource "index.html" [ "index.html" ] None
 

--- a/src/Init.fs
+++ b/src/Init.fs
@@ -15,6 +15,7 @@ let init (projectDir: AbsoluteProjectDir) =
         writeResource "PROJECT_NAME.fsproj" [ $"%s{(ProjectName.asString >> String.asKebabCase) projectName}.fsproj" ] None
         writeResource "global.json" [ "global.json" ] None
         writeResource "index.html" [ "index.html" ] None
+        writeResource ".gitignore" [ ".gitignore" ] None
 
         writeResource
             "package.json"

--- a/src/templates/.gitignore
+++ b/src/templates/.gitignore
@@ -3,3 +3,5 @@ fable_modules
 node_modules
 bin
 obj
+
+.fake

--- a/src/templates/PROJECT_NAME.fsproj
+++ b/src/templates/PROJECT_NAME.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/templates/PROJECT_NAME.fsproj
+++ b/src/templates/PROJECT_NAME.fsproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/templates/PROJECT_NAME.fsproj
+++ b/src/templates/PROJECT_NAME.fsproj
@@ -10,6 +10,7 @@
         <Compile Include="src/Shared.fs"/>
         <Compile Include="src/Pages/Home/Page.fs"/>
         <Compile Include="src/App.fs"/>
+        <Content Include=".gitignore" />
         <Content Include="global.json" />
         <Content Include="index.html" />
         <Content Include="package.json" />

--- a/src/templates/settings.json
+++ b/src/templates/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.exclude": {
+    "**/bin": true,
+    "**/obj": true,
+    "**/*.fs.js": true,
+    "**/fable_modules": true
+  }
+}


### PR DESCRIPTION
This PR includes some improvements to make it nice to work with vscode:

* VS code and other linters complain about the name field not being in kebab case, so we convert the project name
* Add .gitignore
* Hide fable modules and other generated files from the file view