### PR TITLE
Ignore vscode config stuff

### DIFF
--- a/src/templates/.gitignore
+++ b/src/templates/.gitignore
@@ -5,3 +5,4 @@ bin
 obj
 
 .fake
+.vscode


### PR DESCRIPTION
The .vscode folder should not be source controlled for initialized project since it might not be used by all and is only related to the editor and not the code