### PR TITLE
Add support for modules with namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Projects whose name contains a namespace, e.g. `MyOrg.MyProject`, now build. Each dot separated part of the name is escaped individually, so the generated modules form a real namespace instead of a single identifier containing a dot, see https://github.com/reaptor/elmish-land/pull/42
+
 ## [2.0.0 beta 2] - 2026-07-03
 
 ### Changed

--- a/src/TemplateEngine.fs
+++ b/src/TemplateEngine.fs
@@ -199,7 +199,7 @@ let getSortedLayoutFiles absoluteProjectDir =
     }
 
 let wrapWithTicksIfNeeded (s: string) =
-    if Regex.IsMatch(s, "^[0-9a-zA-Z_]+$") && not (Array.contains s reservedWords) then
+    if Regex.IsMatch(s, "^[0-9a-zA-Z_.]+$") && not (Array.contains s reservedWords) then
         s
     else
         $"``%s{s}``"

--- a/src/TemplateEngine.fs
+++ b/src/TemplateEngine.fs
@@ -198,11 +198,20 @@ let getSortedLayoutFiles absoluteProjectDir =
                 |> Ok
     }
 
+// Each dot separated part is checked individually so that a namespaced name, such as
+// MyOrg.MyProject, becomes a real namespace instead of a single identifier containing a dot.
 let wrapWithTicksIfNeeded (s: string) =
-    if Regex.IsMatch(s, "^[0-9a-zA-Z_.]+$") && not (Array.contains s reservedWords) then
-        s
-    else
-        $"``%s{s}``"
+    s
+    |> String.split "."
+    |> Array.map (fun part ->
+        if
+            Regex.IsMatch(part, "^[0-9a-zA-Z_]+$")
+            && not (Array.contains part reservedWords)
+        then
+            part
+        else
+            $"``%s{part}``")
+    |> String.concat "."
 
 let toPascalCase (s: string) = $"%s{s[0..0].ToUpper()}%s{s[1..]}"
 let toCamelCase (s: string) = $"%s{s[0..0].ToLower()}%s{s[1..]}"

--- a/tests/CommandTests.fs
+++ b/tests/CommandTests.fs
@@ -18,7 +18,7 @@ open TestProjectGeneration
 
 [<Fact>]
 let ``addPage creates page with correct indentation in preview and fsproj`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             // Run addPage with auto-accept = true to avoid user interaction
             let! result, logs =
@@ -112,7 +112,7 @@ let ``addPage creates page with correct indentation in preview and fsproj`` () =
 
 [<Fact>]
 let ``addLayout after addPage updates project file order and page layout reference`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             // Step 1: Add a page first
             let! addPageResult, addPageLogs =
@@ -179,7 +179,7 @@ let ``addLayout after addPage updates project file order and page layout referen
 
 [<Fact>]
 let ``nested layout with page uses correct layout message reference`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             // Step 1: Add nested layout first
             let! addLayoutResult, addLayoutLogs =
@@ -265,7 +265,7 @@ let ``nested layout with page uses correct layout message reference`` () =
 
 [<Fact>]
 let ``validate should report missing files and only check layout references for pages in project file`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             // Create an additional page file that is NOT in the project file
             // This page uses the main Layout.Msg which would normally be flagged as wrong
@@ -401,7 +401,7 @@ Compilation failed
 
 [<Fact>]
 let ``Wrong layout reference in page should generate helpful error message`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             // Step 1: Add an About page with its own layout
             let! addLayoutResult, addLayoutLogs =
@@ -463,7 +463,7 @@ Compilation failed"""
 
 [<Fact>]
 let ``Add layout and then page, page uses correct layout`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         eff {
             do! addLayout (AbsoluteProjectDir.asFilePath projectDir) projectDir "/About" AutoAccept
             do! addPage (AbsoluteProjectDir.asFilePath projectDir) projectDir "/About" AutoAccept
@@ -475,7 +475,7 @@ let ``Add layout and then page, page uses correct layout`` () =
 
 [<Fact>]
 let ``Add nested layouts and then pages, page uses correct layout`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         eff {
             do! addLayout (AbsoluteProjectDir.asFilePath projectDir) projectDir "/About" AutoAccept
             do! addPage (AbsoluteProjectDir.asFilePath projectDir) projectDir "/About" AutoAccept
@@ -490,7 +490,7 @@ let ``Add nested layouts and then pages, page uses correct layout`` () =
 
 [<Fact>]
 let ``Sibling pages sharing a layout batch the layout command once and still type-check`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let dir = AbsoluteProjectDir.asFilePath projectDir
 
@@ -524,7 +524,7 @@ let ``Sibling pages sharing a layout batch the layout command once and still typ
 
 [<Fact>]
 let ``Nested page with wrong layout reference should generate correct error message`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             // Step 1: Add About layout
             let! addLayoutResult, addLayoutLogs =
@@ -587,7 +587,7 @@ Compilation failed"""
 
 [<Fact>]
 let ``initFiles creates project files without CLI commands`` () =
-    withNewProject (fun absoluteProjectDir routeData ->
+    withNewProject "Proj" (fun absoluteProjectDir routeData ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
 
@@ -662,7 +662,7 @@ let ``initFiles creates project files without CLI commands`` () =
 let ``Add page command with multiple URL parts, own layout and auto updating layout reference, updates correct layout reference in page``
     ()
     =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
 
@@ -679,7 +679,7 @@ let ``Add page command with multiple URL parts, own layout and auto updating lay
 
 [<Fact>]
 let ``Ensure auto accept layout change write correct namespace`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
 
@@ -703,11 +703,15 @@ let ``Ensure auto accept layout change write correct namespace`` () =
 
 [<Fact>]
 let ``Init command creates a buildable project`` () =
-    withNewProject (fun projectDir _ -> expectProjectTypeChecks projectDir)
+    withNewProject "Proj" (fun projectDir _ -> expectProjectTypeChecks projectDir)
+
+[<Fact>]
+let ``Init command creates a buildable project when the project name contains a namespace`` () =
+    withNewProject "MyOrg.MyProject" (fun projectDir _ -> expectProjectTypeChecks projectDir)
 
 [<Fact>]
 let ``Init command with UserPromptBehaviour Accept, initializes project with route mode "hash"`` () =
-    withEmptyProjectFolder (fun absoluteProjectDir ->
+    withEmptyProjectFolder "Proj" (fun absoluteProjectDir ->
         task {
             let nodeVersion = Version(20, 0, 0)
 
@@ -731,7 +735,7 @@ let ``Init command with UserPromptBehaviour Accept, initializes project with rou
 
 [<Fact>]
 let ``Init command with UserPromptBehaviour Decline, initializes project with route mode "path"`` () =
-    withEmptyProjectFolder (fun absoluteProjectDir ->
+    withEmptyProjectFolder "Proj" (fun absoluteProjectDir ->
         task {
             let nodeVersion = Version(20, 0, 0)
 
@@ -755,7 +759,7 @@ let ``Init command with UserPromptBehaviour Decline, initializes project with ro
 
 [<Fact>]
 let ``Ensure orphan page files are reported as validation errors`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
 
@@ -776,7 +780,7 @@ let ``Ensure orphan page files are reported as validation errors`` () =
 
 [<Fact>]
 let ``upgradeFiles updates Directory.Packages.props versions and preserves user-added entries`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
             let propsPath = Path.Combine(folder, "Directory.Packages.props")
@@ -831,7 +835,7 @@ let ``upgradeFiles updates Directory.Packages.props versions and preserves user-
 
 [<Fact>]
 let ``upgradeFiles removes Feliz.Router PackageVersion from Directory.Packages.props`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
             let propsPath = Path.Combine(folder, "Directory.Packages.props")
@@ -869,7 +873,7 @@ let ``upgradeFiles removes Feliz.Router PackageVersion from Directory.Packages.p
 
 [<Fact>]
 let ``upgradeUserProjectFiles strips Feliz.Router PackageReference from user fsproj`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
             let projPath = Path.Combine(folder, "fsproj-with-router.fsproj")
@@ -895,7 +899,7 @@ let ``upgradeUserProjectFiles strips Feliz.Router PackageReference from user fsp
 
 [<Fact>]
 let ``upgradeFiles adds a managed package to Directory.Packages.props when missing`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
             let propsPath = Path.Combine(folder, "Directory.Packages.props")
@@ -930,7 +934,7 @@ let ``upgradeFiles adds a managed package to Directory.Packages.props when missi
 
 [<Fact>]
 let ``upgradeFiles updates package.json versions and preserves user-added dependencies`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
             let packageJsonPath = Path.Combine(folder, "package.json")
@@ -976,7 +980,7 @@ let ``upgradeFiles updates package.json versions and preserves user-added depend
 
 [<Fact>]
 let ``upgradeFiles updates dotnet-tools.json version while preserving user-added tools`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
             let configDir = Path.Combine(folder, ".config")
@@ -1035,7 +1039,7 @@ let ``upgradeFiles updates dotnet-tools.json version while preserving user-added
 
 [<Fact>]
 let ``upgrade fails with ElmishLandProjectMissing when no elmish-land.json files exist`` () =
-    withEmptyProjectFolder (fun absoluteProjectDir ->
+    withEmptyProjectFolder "Proj" (fun absoluteProjectDir ->
         task {
             Directory.CreateDirectory(AbsoluteProjectDir.asString absoluteProjectDir)
             |> ignore

--- a/tests/SettingsTests.fs
+++ b/tests/SettingsTests.fs
@@ -29,7 +29,7 @@ type AppConfig() =
 
 [<Fact>]
 let ``Default renderMethod is written to App.fs`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let workingDir = AbsoluteProjectDir.asString projectDir
 
@@ -47,7 +47,7 @@ let ``Default renderMethod is written to App.fs`` () =
 
 [<Fact>]
 let ``Changing renderMethod to batched writes it to App.fs`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let workingDir = AbsoluteProjectDir.asString projectDir
 
@@ -72,7 +72,7 @@ let ``Changing renderMethod to batched writes it to App.fs`` () =
 
 [<Fact>]
 let ``Default routeMode is "hash"`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let workingDir = AbsoluteProjectDir.asString projectDir
 
@@ -86,7 +86,7 @@ let ``Default routeMode is "hash"`` () =
 
 [<Fact>]
 let ``Missing routeMode uses "hash"`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let workingDir = AbsoluteProjectDir.asString projectDir
 
@@ -103,7 +103,7 @@ let ``Missing routeMode uses "hash"`` () =
 
 [<Fact>]
 let ``Changing routeMode to "path" generates correct App.fs, Routes.fs and Command.fs`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let workingDir = AbsoluteProjectDir.asString projectDir
 
@@ -120,7 +120,7 @@ let ``Changing routeMode to "path" generates correct App.fs, Routes.fs and Comma
 
 [<Fact>]
 let ``Default fable settings have server noCache false and build noCache true`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let! result, logs = getSettings projectDir |> runEff
 
@@ -131,7 +131,7 @@ let ``Default fable settings have server noCache false and build noCache true`` 
 
 [<Fact>]
 let ``Custom fable settings are parsed from elmish-land.json`` () =
-    withNewProject (fun projectDir _ ->
+    withNewProject "Proj" (fun projectDir _ ->
         task {
             let workingDir = AbsoluteProjectDir.asString projectDir
             let filepath = Path.Combine(workingDir, "elmish-land.json")

--- a/tests/SharedModuleTests.fs
+++ b/tests/SharedModuleTests.fs
@@ -11,7 +11,7 @@ open TestProjectGeneration
 
 [<Fact>]
 let ``Init function in Shared can handle promises`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
 

--- a/tests/TemplateEngineTests.fs
+++ b/tests/TemplateEngineTests.fs
@@ -355,8 +355,83 @@ let ``Ensure module names is wrapped in double ticks if project dir contains spe
     }
 
 [<Fact>]
+let ``Ensure each dot separated part of a name is wrapped in double ticks individually`` () =
+    // A project named MyOrg.MyProject must produce a real two part namespace, not a
+    // single identifier containing a dot.
+    wrapWithTicksIfNeeded "MyOrg.MyProject" |> Expects.equals "MyOrg.MyProject"
+    // Only the part that needs escaping is escaped.
+    wrapWithTicksIfNeeded "type.Api" |> Expects.equals "``type``.Api"
+    wrapWithTicksIfNeeded "My-Org.Project" |> Expects.equals "``My-Org``.Project"
+    // Names without dots are unaffected.
+    wrapWithTicksIfNeeded "TestProject" |> Expects.equals "TestProject"
+    wrapWithTicksIfNeeded "test-project" |> Expects.equals "``test-project``"
+
+[<Fact>]
+let ``Ensure module names are not wrapped in double ticks if project dir contains a namespace`` () =
+    let tempDir = Path.Combine(Path.GetTempPath(), "test_" + Guid.NewGuid().ToString())
+    let testProjectDir = Path.Combine(tempDir, "My.Test.Project")
+    let projectDir = FilePath.fromString testProjectDir
+    let absoluteProjectDir = AbsoluteProjectDir projectDir
+
+    task {
+        try
+            Directory.CreateDirectory(Path.Combine(testProjectDir, "src", "Pages"))
+            |> ignore
+
+            File.WriteAllText(Path.Combine(testProjectDir, "src", "Pages", "Page.fs"), "module Page")
+            File.WriteAllText(Path.Combine(testProjectDir, "src", "Pages", "Layout.fs"), "module Layout")
+            File.WriteAllText(Path.Combine(testProjectDir, "elmish-land.json"), "{}")
+
+            let! result, logs =
+                getTemplateData (ProjectName.fromAbsoluteProjectDir absoluteProjectDir) absoluteProjectDir
+                |> runEff
+
+            result
+            |> Expects.ok logs
+            |> Expects.equalsWLogs logs {
+                RenderFunction = "withReactSynchronous"
+                RenderTargetElementId = "app"
+                ViewModule = "Feliz"
+                ViewType = "ReactElement"
+                RootModule = "My.Test.Project"
+                ElmishLandAppProjectFullName = "ElmishLand.My.Test.Project.App"
+                Routes = [|
+                    {
+                        Name = "Home"
+                        RouteName = "HomeRoute"
+                        LayoutName = "Main"
+                        LayoutModuleName = "My.Test.Project.Pages.Layout"
+                        LayoutModulePath = ""
+                        MsgName = "HomeMsg"
+                        ModuleName = "My.Test.Project.Pages.Page"
+                        RecordDefinition = "unit"
+                        RecordConstructor = "()"
+                        RecordPattern = "()"
+                        UrlUsage = """ "" """.Trim()
+                        UrlPattern = "[ Query _ ]"
+                        IsMainLayout = true
+                        UrlPatternWhen = ""
+                    }
+                |]
+                Layouts = [|
+                    {
+                        Name = "Main"
+                        MsgName = "MainMsg"
+                        ModuleName = "My.Test.Project.Pages.Layout"
+                        ModulePath = ""
+                    }
+                |]
+                RouteParamModules = []
+                UseRouterPathMode = false
+            }
+        finally
+            if Directory.Exists(tempDir) then
+                Directory.Delete(tempDir, true)
+    }
+
+[<Fact>]
 let ``Ensure static routes takes precedence over dynamic routes`` () =
-    withNewProject (fun absoluteProjectDir _ ->
+    withNewProject "Proj" (fun absoluteProjectDir _ ->
         task {
             let folder = AbsoluteProjectDir.asString absoluteProjectDir
 

--- a/tests/TestProjectGeneration.fs
+++ b/tests/TestProjectGeneration.fs
@@ -14,8 +14,8 @@ open Xunit
 open Orsak
 open Ionide.ProjInfo
 
-let getFolder () =
-    Path.Combine(Environment.CurrentDirectory, "Proj_" + Guid.NewGuid().ToString().Replace("-", ""))
+let getFolder (projectName: string) =
+    Path.Combine(Environment.CurrentDirectory, projectName + "_" + Guid.NewGuid().ToString().Replace("-", ""))
 
 let leadingWhitespace (s: string) =
     let mutable i = 0
@@ -27,9 +27,9 @@ let leadingWhitespace (s: string) =
 
 let dotnetSdkVersion = DotnetSdkVersion(Version(10, 0, 103))
 
-let withEmptyProjectFolder (f: AbsoluteProjectDir -> Task<_>) : Task<unit> =
+let withEmptyProjectFolder (projectName: string) (f: AbsoluteProjectDir -> Task<_>) : Task<unit> =
     task {
-        let folder = getFolder ()
+        let folder = getFolder projectName
 
         try
             let absoluteProjectDir = AbsoluteProjectDir(FilePath.fromString folder)
@@ -39,8 +39,8 @@ let withEmptyProjectFolder (f: AbsoluteProjectDir -> Task<_>) : Task<unit> =
                 Directory.Delete(folder, true)
     }
 
-let withNewProject (f: AbsoluteProjectDir -> TemplateData -> Task<_>) : Task<unit> =
-    withEmptyProjectFolder (fun absoluteProjectDir ->
+let withNewProject (projectName: string) (f: AbsoluteProjectDir -> TemplateData -> Task<_>) : Task<unit> =
+    withEmptyProjectFolder projectName (fun absoluteProjectDir ->
         task {
             let nodeVersion = Version(20, 0, 0)
 


### PR DESCRIPTION
`wrapWithTicksIfNeeded` should permit the `.` character to allow namespaces to be used with modules, e.g., `MyOrganization.MyProject`

Using the `<Organization>.<Technology>` convention in project names and namespaces will cause the existing code to break. For example, this sequence will fail to build without this proposed change to `wrapWithTicksIfNeeded`:

```
mkdir MyOrg.MyProject
cd MyOrg.MyProject
dotnet tool install elmish-land
dotnet elmish-land init
dotnet elmish-land server
```
